### PR TITLE
Fix memory_resource tests

### DIFF
--- a/.upstream-tests/test/cuda/memory_resource/get_property/forward_property.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/get_property/forward_property.pass.cpp
@@ -14,8 +14,8 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/std/cassert>
-#include <cuda/memory_resource>
+#include <hip/std/cassert>
+#include <hip/memory_resource>
 
 namespace has_upstream_resource {
   struct Upstream{};

--- a/.upstream-tests/test/cuda/memory_resource/get_property/get_property.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/get_property/get_property.pass.cpp
@@ -15,8 +15,8 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/std/cassert>
-#include <cuda/memory_resource>
+#include <hip/std/cassert>
+#include <hip/memory_resource>
 
 struct prop_with_value {
   using value_type = int;

--- a/.upstream-tests/test/cuda/memory_resource/get_property/has_property.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/get_property/has_property.pass.cpp
@@ -15,7 +15,7 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
 struct prop_with_value {
   using value_type = int;

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.allocate.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.allocate.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 struct async_resource {
   void* allocate(std::size_t, std::size_t) { return &_val; }

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.construction.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.construction.pass.cpp
@@ -15,9 +15,9 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cstdint>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.conversion.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.conversion.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.fail.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.fail.cpp
@@ -15,11 +15,11 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <hip/memory_resource>
+#include <hip/stream_ref>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.pass.cpp
@@ -15,11 +15,11 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <hip/memory_resource>
+#include <hip/stream_ref>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.inheritance.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.inheritance.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.properties.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.properties.pass.cpp
@@ -15,11 +15,11 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <hip/memory_resource>
+#include <hip/stream_ref>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/async_resource.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/async_resource.pass.cpp
@@ -15,9 +15,9 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cstdint>
+#include <hip/std/cstdint>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/async_resource_with.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/async_resource_with.pass.cpp
@@ -15,9 +15,9 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cstdint>
+#include <hip/std/cstdint>
 
 struct prop_with_value {};
 struct prop {};

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/resource.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/resource.pass.cpp
@@ -15,9 +15,9 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cstdint>
+#include <hip/std/cstdint>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/resource_with.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.concepts/resource_with.pass.cpp
@@ -15,9 +15,9 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cstdint>
+#include <hip/std/cstdint>
 
 struct prop_with_value {};
 struct prop {};

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.allocate.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.allocate.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 struct resource {
   void* allocate(std::size_t, std::size_t) { return &_val; }

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.construction.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.construction.pass.cpp
@@ -15,9 +15,9 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cstdint>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.conversion.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.conversion.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.fail.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.fail.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.inheritance.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.inheritance.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {

--- a/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.properties.pass.cpp
+++ b/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.properties.pass.cpp
@@ -15,10 +15,10 @@
 
 #define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#include <cuda/memory_resource>
+#include <hip/memory_resource>
 
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
+#include <hip/std/cassert>
+#include <hip/std/cstdint>
 
 template <class T>
 struct property_with_value {


### PR DESCRIPTION
This PR Fixes memory_resource tests to use hip in their include path.

