### PR TITLE
[ROCM-1365] Fixes unsupported architecture issues: cherry-pick for theRock 7.11 

### DIFF
--- a/.upstream-tests/utils/amd/hiprtc/hiprtcc.cpp
+++ b/.upstream-tests/utils/amd/hiprtc/hiprtcc.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Modifications Copyright (c) 2025 Advanced Micro Devices, Inc.
+// Modifications Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -68,8 +68,8 @@ int g_argc;
 char** g_argv;
 
 // Ignore PTX arch, only capture output version since PTX only compilation *must* be the same
-std::regex real_capture(R"((?:--offload-arch=)?(gfx(90[8a]|94[012]|1030|110[01]|120[01]|950)))");
-std::regex virtual_capture(R"((?:--offload-arch=)?(gfx(90[8a]|94[012]|1030|110[01]|120[01]|950)))"); // NOTE(HIP): HIP does not support virtual archs
+std::regex real_capture(R"((?:--offload-arch=)?(gfx(90.|94.|95.|10..|11..|12..)))");
+std::regex virtual_capture(R"((?:--offload-arch=)?(gfx(90.|94.|95.|10..|11..|12..)))"); // NOTE(HIP): HIP does not support virtual archs
 
 // Arch list is a set of unique pairs of strings and bools
 // e.x. { compute_arch, real_or_virtual }

--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Modifications Copyright (c) 2024-2025 Advanced Micro Devices, Inc.
+// Modifications Copyright (c) 2024-2026 Advanced Micro Devices, Inc.
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -1378,23 +1378,30 @@ __sanitizer_annotate_contiguous_container(const void*, const void*, const void*,
 // gfx940 gfx941,gfx942 and gfx950: 100 MHz TSC for wall_clock64 -> 1*1e9/100*1e6 ns/cycle = 10 ns/cycle
 #      elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__)
 #        define _LIBCUDACXX_HIP_TSC_CLOCKRATE 100000000
+#        define _LIBCUDACXX_HIP_TSC_NANOSECONDS_PER_CYCLE 10 // (1/_LIBCUDACXX_HIP_TSC_CLOCKRATE)
+// other gfx9 arch: we assume 100 MHz TSC for wall_clock64 -> 1*1e9/100*1e6 ns/cycle = 10 ns/cycle
+#      elif defined(__GFX9__)
+#        ifndef NDEBUG
+#          warning Assuming 100 MHz realtime clock rate (TSC) for this gfx9 architecture. Timing-related APIs (e.g., chrono) or sleep instructions may behave incorrectly!
+#        endif
+#        define _LIBCUDACXX_HIP_TSC_CLOCKRATE 100000000
 #        define _LIBCUDACXX_HIP_TSC_NANOSECONDS_PER_CYCLE 10 // (1/_LIBCUDACXX_HIP_TSC_CLOCKRATE)  
 // gfx1030 : no info from the RDNA2 ISA docs
-#      elif defined(__gfx1030__)
+#      elif defined(__GFX10__)
 #        ifndef NDEBUG
 #          warning Assuming 100 MHz realtime clock rate (TSC) for gfx1030. Timing-related APIs (e.g., chrono) or sleep instructions may behave incorrectly!
 #        endif
 #        define _LIBCUDACXX_HIP_TSC_CLOCKRATE 100000000
 #        define _LIBCUDACXX_HIP_TSC_NANOSECONDS_PER_CYCLE 10 // (1/_LIBCUDACXX_HIP_TSC_CLOCKRATE)
 // gfx1100 and gfx1101 : from the RDNA3 ISA docs: "constantly running clock (typically 100MHz)"
-#      elif defined(__gfx1100__) || defined(__gfx1101__)
+#      elif defined(__GFX11__)
 #        ifndef NDEBUG
 #          warning Assuming 100 MHz realtime clock rate (TSC) for gfx1100/gfx1101 (according to the RDNA3 ISA). Timing-related APIs (e.g., chrono) or sleep instructions may behave incorrectly!
 #        endif
 #        define _LIBCUDACXX_HIP_TSC_CLOCKRATE 100000000
 #        define _LIBCUDACXX_HIP_TSC_NANOSECONDS_PER_CYCLE 10 // (1/_LIBCUDACXX_HIP_TSC_CLOCKRATE)
 // gfx1200 and gfx1201: ASSUMED: 100 MHz TSC for wall_clock64 -> 1*1e9/100*1e6 ns/cycle = 10 ns/cycle
-#      elif defined(__gfx1200__) || defined(__gfx1201__)
+#      elif defined(__GFX12__)
 #        ifndef NDEBUG
 #          warning Assuming 100 MHz realtime clock rate (TSC) for gfx1200/gfx1201 (from the RDNA4 ISA). Timing-related APIs (e.g., chrono) or sleep instructions may behave incorrectly!
 #        endif


### PR DESCRIPTION
This PR fixes issues when libhipcxx is build for an unsupported architecture by increasing the support to a broader set of architectures for compilation and testing.

Fixes issue in https://amd-hub.atlassian.net/browse/ROCM-1365.
