### PR TITLE
[ci] Deprecate hipcc: use amdclang++ as default compiler

### DIFF
--- a/.upstream-tests/test/CMakeLists.txt
+++ b/.upstream-tests/test/CMakeLists.txt
@@ -186,6 +186,7 @@ if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "AMDCLANG")
     " -I${CMAKE_SOURCE_DIR}/include"
     " -I${libhipcxx_SOURCE_DIR}/include"
     " -I${libhipcxx_SOURCE_DIR}/include/libhipcxx"
+    " -O3"  # hipcc defaults to -O3; amdclang++ invoked directly does not
 #    " CACHE INTERNAL "Flags for libcxx testing."
   )
   # hipcc used to add the HIP runtime library automatically; with amdclang++

--- a/.upstream-tests/test/CMakeLists.txt
+++ b/.upstream-tests/test/CMakeLists.txt
@@ -183,12 +183,19 @@ if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "AMDCLANG")
   message(STATUS "libhipcxx_SOURCE_DIR: ${libhipcxx_SOURCE_DIR}" )
   string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS
 #    "${LIBCUDACXX_TEST_COMPILER_FLAGS} \
-    " ${LIBCUDACXX_FORCE_INCLUDE}" 
+    " ${LIBCUDACXX_FORCE_INCLUDE}"
     " -I${CMAKE_SOURCE_DIR}/include"
     " -I${libhipcxx_SOURCE_DIR}/include"
     " -I${libhipcxx_SOURCE_DIR}/include/libhipcxx"
 #    " CACHE INTERNAL "Flags for libcxx testing."
   )
+  # hipcc used to add the HIP runtime library automatically; with amdclang++
+  # we must link it explicitly.
+  get_target_property(_amdhip64_loc hip::amdhip64 LOCATION)
+  cmake_path(GET _amdhip64_loc PARENT_PATH _hip_lib_dir)
+  string(APPEND LIBCUDACXX_TEST_LINKER_FLAGS
+    " -L${_hip_lib_dir}"
+    " -lamdhip64")
 endif()
 
 set(LIBCUDACXX_COMPUTE_ARCHS_STRING "${CMAKE_HIP_ARCHITECTURES}")

--- a/.upstream-tests/test/CMakeLists.txt
+++ b/.upstream-tests/test/CMakeLists.txt
@@ -189,6 +189,14 @@ if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "AMDCLANG")
     " -O3"  # hipcc defaults to -O3; amdclang++ invoked directly does not
 #    " CACHE INTERNAL "Flags for libcxx testing."
   )
+  if (WIN32)
+    # On Windows, MxGPU virtual GPUs cause offload-arch.exe to return the
+    # wrong arch (e.g. gfx906). Add --offload-arch=native so amdclang++
+    # queries the HIP runtime directly at compile time to get the real GPU
+    # arch (e.g. gfx1101). lit's config.py ignores "native" for the hipcc
+    # compiler type, so this must be injected explicitly here.
+    string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS " --offload-arch=native")
+  endif()
   # hipcc used to add the HIP runtime library automatically; with amdclang++
   # we must link it explicitly.
   # On Windows, the DLL (amdhip64.dll) is in bin/ but the import library

--- a/.upstream-tests/test/CMakeLists.txt
+++ b/.upstream-tests/test/CMakeLists.txt
@@ -188,8 +188,28 @@ if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "AMDCLANG")
     " -I${libhipcxx_SOURCE_DIR}/include/libhipcxx"
 #    " CACHE INTERNAL "Flags for libcxx testing."
   )
-  get_target_property(_amdhip64_loc hip::amdhip64 LOCATION)
-  cmake_path(GET _amdhip64_loc PARENT_PATH _hip_lib_dir)
+  # hipcc used to add the HIP runtime library automatically; with amdclang++
+  # we must link it explicitly.
+  # On Windows, the DLL (amdhip64.dll) is in bin/ but the import library
+  # (amdhip64.lib) is in lib/. Try IMPORTED_IMPLIB variants first; if none
+  # are set, derive lib/ by going up from the DLL's bin/ directory.
+  set(_hip_lib_dir "")
+  foreach(_cfg "" "_RELEASE" "_DEBUG" "_RELWITHDEBINFO" "_MINSIZEREL")
+    get_target_property(_amdhip64_implib hip::amdhip64 "IMPORTED_IMPLIB${_cfg}")
+    if(_amdhip64_implib)
+      cmake_path(GET _amdhip64_implib PARENT_PATH _hip_lib_dir)
+      break()
+    endif()
+  endforeach()
+  if(NOT _hip_lib_dir)
+    get_target_property(_amdhip64_loc hip::amdhip64 LOCATION)
+    cmake_path(GET _amdhip64_loc PARENT_PATH _hip_lib_dir)
+    if(WIN32)
+      # DLL is in bin/, import lib is in lib/ — go up one and use lib/
+      cmake_path(GET _hip_lib_dir PARENT_PATH _hip_root_dir)
+      set(_hip_lib_dir "${_hip_root_dir}/lib")
+    endif()
+  endif()
   string(APPEND LIBCUDACXX_TEST_LINKER_FLAGS
     " -L${_hip_lib_dir}"
     " -lamdhip64")

--- a/.upstream-tests/test/CMakeLists.txt
+++ b/.upstream-tests/test/CMakeLists.txt
@@ -110,9 +110,8 @@ else() # NOT LIBCUDACXX_TEST_WITH_NVRTC
     set(LIBCUDACXX_TEST_COMPILER_FLAGS "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE")
   elseif(LIBCUDACXX_ENABLE_HIP)
     set(LIBCUDACXX_FORCE_INCLUDE "-include ${libhipcxx_SOURCE_DIR}/test/force_include_hip.h")
-    # Select compiler based on HIP_PLATFORM env var, mirroring hipcc's own
-    # platform detection logic. HIP_PLATFORM=nvidia uses nvcc; everything
-    # else (including the default unset case) uses amdclang++ directly.
+    # Select compiler based on HIP_PLATFORM env var HIP_PLATFORM
+    # if HIP_PLAFORM=nvidia use nvcc; else use amdclang++.
     if("$ENV{HIP_PLATFORM}" STREQUAL "nvidia" OR "$ENV{HIP_PLATFORM}" STREQUAL "nvcc")
       find_program(NVCC_EXECUTABLE nvcc REQUIRED)
       set(LIBCUDACXX_CUDA_COMPILER "${NVCC_EXECUTABLE}")
@@ -189,8 +188,6 @@ if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "AMDCLANG")
     " -I${libhipcxx_SOURCE_DIR}/include/libhipcxx"
 #    " CACHE INTERNAL "Flags for libcxx testing."
   )
-  # hipcc used to add the HIP runtime library automatically; with amdclang++
-  # we must link it explicitly.
   get_target_property(_amdhip64_loc hip::amdhip64 LOCATION)
   cmake_path(GET _amdhip64_loc PARENT_PATH _hip_lib_dir)
   string(APPEND LIBCUDACXX_TEST_LINKER_FLAGS

--- a/.upstream-tests/test/CMakeLists.txt
+++ b/.upstream-tests/test/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 if (LIBCUDACXX_TEST_WITH_NVRTC)
   # TODO: Use project properties to get path to binary.
   # Should also set up dependency on the project when NVRTC is enabled
+  set(CMAKE_CUDA_COMPILER_ID "NVIDIA")
   set(LIBCUDACXX_CUDA_COMPILER "${CMAKE_BINARY_DIR}/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc")
   set(LIBCUDACXX_CUDA_COMPILER_ARG1 "")
   set(LIBCUDACXX_CUDA_TEST_WITH_NVRTC "True")
@@ -75,7 +76,9 @@ if (LIBCUDACXX_TEST_WITH_NVRTC)
 elseif (LIBHIPCXX_TEST_WITH_HIPRTC)
   # TODO: Use project properties to get path to binary.
   # Should also set up dependency on the project when NVRTC is enabled
-  set(CMAKE_CUDA_COMPILER_ID "HIPCC")
+  # HIPRTC is the AMD runtime; use the same HIP_PLATFORM-based compiler
+  # selection as the offline compilation path below.
+  set(CMAKE_CUDA_COMPILER_ID "AMDCLANG")
   set(LIBCUDACXX_CUDA_COMPILER "${CMAKE_BINARY_DIR}/libcudacxx/test/utils/amd/hiprtc/hiprtcc${CMAKE_EXECUTABLE_SUFFIX}")
   message(STATUS "LIBCUDACXX_CUDA_COMPILER: ${LIBCUDACXX_CUDA_COMPILER}")
   set(LIBCUDACXX_CUDA_COMPILER_ARG1 "")
@@ -107,10 +110,18 @@ else() # NOT LIBCUDACXX_TEST_WITH_NVRTC
     set(LIBCUDACXX_TEST_COMPILER_FLAGS "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE")
   elseif(LIBCUDACXX_ENABLE_HIP)
     set(LIBCUDACXX_FORCE_INCLUDE "-include ${libhipcxx_SOURCE_DIR}/test/force_include_hip.h")
-    #temporary workaround until we've found a way to make cmake find hipcc
-    set(LIBCUDACXX_CUDA_COMPILER "${HIP_HIPCC_EXECUTABLE}")
+    # Select compiler based on HIP_PLATFORM env var, mirroring hipcc's own
+    # platform detection logic. HIP_PLATFORM=nvidia uses nvcc; everything
+    # else (including the default unset case) uses amdclang++ directly.
+    if("$ENV{HIP_PLATFORM}" STREQUAL "nvidia" OR "$ENV{HIP_PLATFORM}" STREQUAL "nvcc")
+      find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+      set(LIBCUDACXX_CUDA_COMPILER "${NVCC_EXECUTABLE}")
+      set(CMAKE_CUDA_COMPILER_ID "NVIDIA")
+    else()
+      set(LIBCUDACXX_CUDA_COMPILER "${CMAKE_CXX_COMPILER}")
+      set(CMAKE_CUDA_COMPILER_ID "AMDCLANG")
+    endif()
     set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
-    set(CMAKE_CUDA_COMPILER_ID "HIPCC")
     set(LIBCUDACXX_CUDA_TEST_WITH_NVRTC "False")
     set(LIBCUDACXX_HIP_TEST_WITH_HIPRTC "False")
     set(LIBCUDACXX_TEST_COMPILER_FLAGS "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE")
@@ -168,7 +179,7 @@ elseif (${CMAKE_CUDA_COMPILER_ID} STREQUAL "NVHPC")
     " -stdpar")
 endif()
 
-if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "HIPCC")
+if (${CMAKE_CUDA_COMPILER_ID} STREQUAL "AMDCLANG")
   message(STATUS "libhipcxx_SOURCE_DIR: ${libhipcxx_SOURCE_DIR}" )
   string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS
 #    "${LIBCUDACXX_TEST_COMPILER_FLAGS} \

--- a/.upstream-tests/utils/amd/hiprtc/CMakeLists.txt
+++ b/.upstream-tests/utils/amd/hiprtc/CMakeLists.txt
@@ -18,10 +18,11 @@
 project(hiprtcc)
 
 enable_language(HIP)
-find_package(HIP REQUIRED)
+find_package(hip CONFIG REQUIRED)
+find_package(hiprtc CONFIG REQUIRED)
 
 add_executable(libcudacxx.nvrtcc hiprtcc.cpp)
 
 set_target_properties(libcudacxx.nvrtcc PROPERTIES OUTPUT_NAME hiprtcc)
-target_link_libraries(libcudacxx.nvrtcc hiprtc hip::host)
+target_link_libraries(libcudacxx.nvrtcc hiprtc::hiprtc hip::host)
 target_compile_features(libcudacxx.nvrtcc PRIVATE cxx_std_17)

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -24,9 +24,9 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
 # Script defaults
 VERBOSE=${VERBOSE:-}
-HOST_COMPILER=${CXX:-hipcc} # $CXX if set, otherwise `g++`
+HOST_COMPILER=${CXX:-amdclang++} # $CXX if set, otherwise `amdclang++`
 CXX_STANDARD=17
-CUDA_COMPILER=${CUDACXX:-hipcc} # $CUDACXX if set, otherwise `nvcc`
+CUDA_COMPILER=${CUDACXX:-amdclang++} # $CUDACXX if set, otherwise `amdclang++`
 CUDA_ARCHS= # Empty, use presets by default.
 GLOBAL_CMAKE_OPTIONS=()
 DISABLE_CUB_BENCHMARKS= # Enable to force-disable building CUB benchmarks.

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -26,7 +26,13 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 VERBOSE=${VERBOSE:-}
 HOST_COMPILER=${CXX:-amdclang++} # $CXX if set, otherwise `amdclang++`
 CXX_STANDARD=17
-CUDA_COMPILER=${CUDACXX:-amdclang++} # $CUDACXX if set, otherwise `amdclang++`
+# Mirror hipcc's platform detection: HIP_PLATFORM=nvidia uses nvcc,
+# everything else (including unset) uses amdclang++ directly.
+if [ "${HIP_PLATFORM:-amd}" = "nvidia" ] || [ "${HIP_PLATFORM:-amd}" = "nvcc" ]; then
+  CUDA_COMPILER=${CUDACXX:-nvcc}
+else
+  CUDA_COMPILER=${CUDACXX:-amdclang++}
+fi
 CUDA_ARCHS= # Empty, use presets by default.
 GLOBAL_CMAKE_OPTIONS=()
 DISABLE_CUB_BENCHMARKS= # Enable to force-disable building CUB benchmarks.

--- a/cmake/test/CMakeLists.txt
+++ b/cmake/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(cmake_opts
   -D "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
   -D "CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
   -D "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+  -D "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
 )
 
 # Temporary installation prefix for tests against installed project:

--- a/cmake/test/test_export/CMakeLists.txt
+++ b/cmake/test/test_export/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(hip REQUIRED)
 find_package(libhipcxx REQUIRED)
 
 add_executable(version_check version_check.cxx)
+target_compile_options(version_check PRIVATE -x hip)
 target_link_libraries(version_check PRIVATE libhipcxx::libhipcxx hip::host)
 enable_testing()
 add_test(NAME version_check COMMAND "$<TARGET_FILE:version_check>")


### PR DESCRIPTION
## Description

The HIPCC Tool will be deprecated, and eventually removed in an upcoming release.  Users will be directed to use amdclang++ instead and will be given a migration guide.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->
Jira: https://amd-hub.atlassian.net/browse/ROCM-8370

<!-- Provide a standalone description of changes in this PR. -->

Replace the hipcc fallback defaults for HOST_COMPILER and CUDA_COMPILER with amdclang++. hipcc is deprecated in favor of calling amdclang++ directly with explicit --hip-path and --hip-device-lib-path flags.

Callers that set $CXX or $CUDACXX are unaffected.

Testing done under https://github.com/ROCm/TheRock/pull/6429. 
Once this PR lands we will need a PR with the submodule bump as well as the changes in build_tools in this PR: https://github.com/ROCm/TheRock/pull/6429

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
