### PR TITLE
Get rid of timing related error

### DIFF
--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -384,7 +384,7 @@ using char32_t = unsigned int;
 #        ifndef _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
 #          ifndef NDEBUG
 #            warning Timing-related utility APIs (e.g., chrono) are currently not supported on the current architecture by libhipcxx. \
-To override this warning and proceed with the build, please set the compile-time flag _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
+To override this warning, please set the compile-time flag _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
 #          endif
 #        endif
          // This should intentionally make no sense and tell the user that the value is meaningless

--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -381,14 +381,11 @@ using char32_t = unsigned int;
 #        define _LIBCUDACXX_HIP_TSC_NANOSECONDS_PER_CYCLE 10 // (1/_LIBCUDACXX_HIP_TSC_CLOCKRATE)
 //       The clock rate on other architectures like gfx1030/RDNA2 is not specified in the ISA docs.
 #      else
-#        ifdef _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
-#          ifndef  NDEBUG
+#        ifndef _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
+#          ifndef NDEBUG
 #            warning Timing-related utility APIs (e.g., chrono) are currently not supported on the current architecture by libhipcxx. \
-Using _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE for these APIs will result in incorrect results (timings).
+To override this warning and proceed with the build, please set the compile-time flag _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
 #          endif
-#        else
-#          error Timing-related utility APIs (e.g., chrono) are currently not supported on the current architecture by libhipcxx. \
-To override this error and proceed with the build, please set the compile-time flag _LIBCUDACXX_ALLOW_UNSUPPORTED_ARCHITECTURE
 #        endif
          // This should intentionally make no sense and tell the user that the value is meaningless
 #        define _LIBCUDACXX_HIP_TSC_CLOCKRATE 1


### PR DESCRIPTION
We want to only emit a warning for unsupported chrono architectures as this otherwise blocks builds on new architectures.