### PR TITLE
Add requirements-test.txt to use on CI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Python dependencies for running the libhipcxx test suite.
+lit==18.1.8
+psutil==7.1.3
+sccache==0.10.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,19 +1,5 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc.
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-License-Identifier: MIT
 
 # Python dependencies for running the libhipcxx test suite.
 lit==18.1.8


### PR DESCRIPTION
## Description

* Progress on https://github.com/ROCm/TheRock/issues/7491
* See also https://github.com/ROCm/rocm-libraries/pull/11396
* See also https://github.com/ROCm/TheRock/pull/2018

We've been using a common https://github.com/ROCm/TheRock/blob/main/requirements-test.txt file across all ROCm subproject tests and these packages are relatively large to download for all subprojects on runners with slow network (sccache is 8-15MB), so I want each project to declare which test requirements it has directly and leave only _CI system_ and _test runner_ requirements in the common file.

The full libhipcxx source is already included in the 'test' artifact in TheRock via https://github.com/ROCm/TheRock/blob/950330ecc2554996ff6a424780a81bf1aff64e32/math-libs/artifact-libhipcxx.toml#L10-L18, so this won't need extra work to start distributing.

## Test Plan

I'm testing this together with some changes in TheRock that will start picking up this requirements file from the test artifact. See https://github.com/ROCm/TheRock/actions/runs/33191445520/job/98940713056. It should be safe to add the requirements here and then start using them from TheRock later.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes. _(Are there tests in this repository that could start using this file directly?)_
- [ ] The documentation is up to date with these changes. _(Would you like this documented somewhere?)_
