### PR TITLE
api!: rename the public CCCL_VERSION family to HIPCCL_*

### DIFF
--- a/.upstream-tests/test/cuda/version.pass.cpp
+++ b/.upstream-tests/test/cuda/version.pass.cpp
@@ -10,9 +10,14 @@
 
 #include <cuda/version>
 
-static_assert(CCCL_MAJOR_VERSION == (CCCL_VERSION / 1000000), "");
-static_assert(CCCL_MINOR_VERSION == (CCCL_VERSION / 1000 % 1000), "");
-static_assert(CCCL_PATCH_VERSION == (CCCL_VERSION % 1000), "");
+static_assert(HIPCCL_MAJOR_VERSION == (HIPCCL_VERSION / 1000000), "");
+static_assert(HIPCCL_MINOR_VERSION == (HIPCCL_VERSION / 1000 % 1000), "");
+static_assert(HIPCCL_PATCH_VERSION == (HIPCCL_VERSION % 1000), "");
+
+// The NVIDIA-branded CCCL_* spellings are gone; make sure they do not creep back.
+#ifdef CCCL_VERSION
+#  error "CCCL_VERSION must not be defined by libhipcxx; use HIPCCL_VERSION"
+#endif
 
 int main(int argc, char** argv)
 {

--- a/include/cuda/std/__cccl/version.h
+++ b/include/cuda/std/__cccl/version.h
@@ -14,13 +14,13 @@
 #ifndef __CCCL_VERSION_H
 #define __CCCL_VERSION_H
 
-#define CCCL_VERSION 3000002
-#define CCCL_MAJOR_VERSION (CCCL_VERSION / 1000000)
-#define CCCL_MINOR_VERSION (((CCCL_VERSION / 1000) % 1000))
-#define CCCL_PATCH_VERSION (CCCL_VERSION % 1000)
+#define HIPCCL_VERSION 3000002
+#define HIPCCL_MAJOR_VERSION (HIPCCL_VERSION / 1000000)
+#define HIPCCL_MINOR_VERSION (((HIPCCL_VERSION / 1000) % 1000))
+#define HIPCCL_PATCH_VERSION (HIPCCL_VERSION % 1000)
 
-#if CCCL_PATCH_VERSION > 99
-#  error "CCCL patch version cannot be greater than 99 for compatibility with Thrust/CUB's MMMmmmpp format."
+#if HIPCCL_PATCH_VERSION > 99
+#  error "HIPCCL patch version cannot be greater than 99 for compatibility with the MMMmmmpp format."
 #endif
 
 #endif // __CCCL_VERSION_H

--- a/include/cuda/std/detail/__config
+++ b/include/cuda/std/detail/__config
@@ -10,7 +10,7 @@
 
 // MIT License
 //
-// Modifications Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Modifications Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -37,10 +37,10 @@
 #endif
 #include <cuda/std/__cccl/version.h> // IWYU pragma: export
 
-#define _LIBCUDACXX_CUDA_API_VERSION       CCCL_VERSION
-#define _LIBCUDACXX_CUDA_API_VERSION_MAJOR CCCL_MAJOR_VERSION
-#define _LIBCUDACXX_CUDA_API_VERSION_MINOR CCCL_MINOR_VERSION
-#define _LIBCUDACXX_CUDA_API_VERSION_PATCH CCCL_PATCH_VERSION
+#define _LIBCUDACXX_CUDA_API_VERSION       HIPCCL_VERSION
+#define _LIBCUDACXX_CUDA_API_VERSION_MAJOR HIPCCL_MAJOR_VERSION
+#define _LIBCUDACXX_CUDA_API_VERSION_MINOR HIPCCL_MINOR_VERSION
+#define _LIBCUDACXX_CUDA_API_VERSION_PATCH HIPCCL_PATCH_VERSION
 
 #ifndef _LIBCUDACXX_CUDA_ABI_VERSION_LATEST
 #  define _LIBCUDACXX_CUDA_ABI_VERSION_LATEST 4

--- a/lib/cmake/libhipcxx/libhipcxx-config-version.cmake
+++ b/lib/cmake/libhipcxx/libhipcxx-config-version.cmake
@@ -1,4 +1,4 @@
-# Modifications Copyright (c) 2024-2025 Advanced Micro Devices, Inc.
+# Modifications Copyright (c) 2024-2026 Advanced Micro Devices, Inc.
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -23,11 +23,18 @@ file(READ "${_libhipcxx_VERSION_INCLUDE_DIR}/cuda/std/__cccl/version.h"
 )
 
 string(REGEX MATCH
-  "#define[ \t]+CCCL_VERSION[ \t]+([0-9]+)" unused_var
+  "#define[ \t]+HIPCCL_VERSION[ \t]+([0-9]+)" unused_var
   "${libhipcxx_VERSION_HEADER}"
 )
 
 set(libhipcxx_VERSION_FLAT ${CMAKE_MATCH_1})
+if(NOT libhipcxx_VERSION_FLAT)
+  message(FATAL_ERROR
+    "Could not parse HIPCCL_VERSION from "
+    "${_libhipcxx_VERSION_INCLUDE_DIR}/cuda/std/__cccl/version.h"
+  )
+endif()
+
 math(EXPR libhipcxx_VERSION_MAJOR "${libhipcxx_VERSION_FLAT} / 1000000")
 math(EXPR libhipcxx_VERSION_MINOR "(${libhipcxx_VERSION_FLAT} / 1000) % 1000")
 math(EXPR libhipcxx_VERSION_PATCH "${libhipcxx_VERSION_FLAT} % 1000")


### PR DESCRIPTION
The version macros exposed by libhipcxx carried NVIDIA's CCCL branding, which is misleading for consumers of a HIP library: CCCL_VERSION named libhipcxx's own release number, not any NVIDIA component's.

Rename the whole public family so the names match the project:

  CCCL_VERSION       -> HIPCCL_VERSION
  CCCL_MAJOR_VERSION -> HIPCCL_MAJOR_VERSION
  CCCL_MINOR_VERSION -> HIPCCL_MINOR_VERSION
  CCCL_PATCH_VERSION -> HIPCCL_PATCH_VERSION

The value is unchanged (3000002) and the documented _LIBCUDACXX_CUDA_API_VERSION alias layer in <cuda/std/detail/__config> keeps working, so code using the documented spelling is unaffected.

Untouched on purpose: the _CCCL_VERSION_* macros in __cccl/compiler.h and __cccl/cuda_toolkit.h. Despite the shared spelling they are unrelated preprocessor machinery behind _CCCL_COMPILER(), _CCCL_CUDACC_*() and _CCCL_CTK_*(), not the release number.

Also:
- Point the libhipcxx-config-version.cmake regex at the new name. It scrapes the header as text, so nothing links it to the header; a stale pattern used to surface as a cryptic "math cannot parse the expression" during a downstream find_package(). Added an explicit FATAL_ERROR when the parse yields nothing.
- Guard the version test against the old spellings reappearing.

BREAKING CHANGE: CCCL_VERSION and its MAJOR/MINOR/PATCH companions are no longer defined. Because an undefined macro evaluates to 0 inside #if, code written as `#if CCCL_VERSION >= ...` will silently stop matching rather than fail to compile. Consumers should switch to HIPCCL_VERSION or to _LIBCUDACXX_CUDA_API_VERSION.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
